### PR TITLE
update gitignore and correct logic error in union

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 sdk/
+.vscode
+.DS_Store

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,7 +511,7 @@ impl Rect {
     }
 
     pub fn union<'a>(&'a mut self, other: &Rect) -> &'a mut Rect {
-        if other.is_empty() {
+        if self.is_empty() {
             *self = *other;
         } else {
             // if !other.is_empty()


### PR DESCRIPTION
As a note porting my current plugins on MacOS i've noticed an issue with the current smart prerender code for requesting the entire frame for output. I could be wrong, but I think i've tracked down the bug to an error in the translation of the `UnionLRect` function. To reproduce run the histo_grid example on macos.  Run the effect on some footage, drag it out of the comp bounds. You should get a dialog stating. 

"...Result rect must not exceed request rect..."

this was reproduced in all of the smart render plugins, so i checked the rect union function against the version in Smart_Utils.h 
```C++
void UnionLRect(const PF_LRect *src, PF_LRect *dst)
{
	if (IsEmptyRect(dst)) {
		*dst = *src;
	} else if (!IsEmptyRect(src)) {
		dst->left 	= mmin(dst->left, src->left);
		dst->top  	= mmin(dst->top, src->top);
		dst->right 	= mmax(dst->right, src->right);
		dst->bottom = mmax(dst->bottom, src->bottom);
	}
}
```
replacing `other.is_empty()` with `self.is_empty()` fixes the issue.
```Rust
    pub fn union<'a>(&'a mut self, other: &Rect) -> &'a mut Rect {
        if other.is_empty() {
            *self = *other;
        } else {
            // if !other.is_empty()
            self.left = min(self.left, other.left);
            self.top = min(self.top, other.top);
            self.right = max(self.right, other.right);
            self.bottom = max(self.bottom, other.bottom);
        }
        self
    }

```