### PR TITLE
Make callback in Parameters::add_group fallible

### DIFF
--- a/src/pf/parameters.rs
+++ b/src/pf/parameters.rs
@@ -1149,7 +1149,7 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
         hasher.finish() as i32
     }
 
-    pub fn add_group<F: FnOnce(&mut Self)>(&mut self, type_start: P, type_end: P, name: &str, inner_cb: F) -> Result<(), Error> {
+    pub fn add_group<F: FnOnce(&mut Self) -> Result<(), Error>>(&mut self, type_start: P, type_end: P, name: &str, inner_cb: F) -> Result<(), Error> {
         assert!(!self.in_data.is_null());
 
         let mut param_def = ParamDef::new(InData::from_raw(self.in_data));
@@ -1160,7 +1160,7 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
         self.map.insert(type_start, ParamMapInfo::new(self.num_params, ParamType::GroupStart));
         self.num_params += 1;
 
-        inner_cb(self);
+        inner_cb(self)?;
 
         let mut param_def = ParamDef::new(InData::from_raw(self.in_data));
         param_def.as_mut().param_type = ParamType::GroupEnd.into();


### PR DESCRIPTION
Since params.add is fallible, and adding params is what we do inside the add_group callback, we should make the callback fallible too so we can properly propagate errors.